### PR TITLE
Improve upload error handling

### DIFF
--- a/src/components/RichTextArea.svelte
+++ b/src/components/RichTextArea.svelte
@@ -29,6 +29,8 @@
 			if (file) {
 				const blob = await uploadBlob(file, $userServers);
 
+				if (!blob) throw new Error('All servers failed');
+
 				// Insert the image URL into the textarea
 				const insert = blob.url;
 				const textarea = event.target as HTMLTextAreaElement;

--- a/src/components/UploadMediaLink.svelte
+++ b/src/components/UploadMediaLink.svelte
@@ -22,6 +22,9 @@
 			try {
 				dispatch('uploading');
 				const blob = await uploadBlob(file, $userServers);
+
+				if (!blob) throw new Error('All servers failed');
+
 				dispatch('uploaded', blob);
 			} catch (error) {
 				if (error instanceof Error) alert(`Failed to upload image: ${error.message}`);


### PR DESCRIPTION
The code in #111 had a potential issue where the upload could fail if the first server in the users server list was offline.

This PR fixes that by making the `uploadBlob` method loop through the servers and first attempt to upload the blob. then mirror it to the remaining servers